### PR TITLE
fix CI issue caused by timeout

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,4 +10,6 @@ on:
 jobs:
   build-and-test:
     uses: GTNewHorizons/GTNH-Actions-Workflows/.github/workflows/build-and-test.yml@master
+    with:
+      timeout: 180
     secrets: inherit


### PR DESCRIPTION
沟槽的构建时间超时直接结束运行runserver
然后ci就报错.....